### PR TITLE
Support for weblate version 4.7

### DIFF
--- a/perceval/backends/weblate/weblate.py
+++ b/perceval/backends/weblate/weblate.py
@@ -264,8 +264,8 @@ class WeblateClient(HttpClient, RateLimitHandler):
             unit = response.json()
             return unit
         except requests.exceptions.HTTPError as error:
-            logger.error("Error fetching {}: {}".format(url, error))
-            raise error
+            logger.warning("Error fetching {}: {}".format(url, error))
+            return
 
     def user(self, url, payload=None):
         """Fetch user data"""
@@ -291,14 +291,15 @@ class WeblateClient(HttpClient, RateLimitHandler):
         """Fetch changes of a project."""
 
         payload = {}
-
         if from_date:
             payload[self.PAFTER] = from_date.isoformat()
 
+        # Since weblate 4.7 'changes' must end with '/' as '.../api/changes/'
+        # or it will return 404 (Page Not Found).
         if self.project:
-            path = urijoin(self.base_url, 'projects', self.project, 'changes')
+            path = urijoin(self.base_url, 'projects', self.project, 'changes') + '/'
         else:
-            path = urijoin(self.base_url, 'changes')
+            path = urijoin(self.base_url, 'changes') + '/'
 
         return self.fetch_items(path, payload)
 

--- a/tests/test_weblate.py
+++ b/tests/test_weblate.py
@@ -184,7 +184,7 @@ class TestWeblateBackend(unittest.TestCase):
         self.assertListEqual(changes_no_timestamp, changes_expected_no_timestamp)
 
         requests_path_expected = [
-            '/api/changes?timestamp_after=1970-01-01T00%3A00%3A00%2B00%3A00',
+            '/api/changes/?timestamp_after=1970-01-01T00%3A00%3A00%2B00%3A00',
             '/api/users/1?id=1&type=user',
             '/api/users/1?id=1&type=author',
             '/api/units/1',
@@ -217,7 +217,7 @@ class TestWeblateBackend(unittest.TestCase):
         self.assertListEqual(changes_no_timestamp, changes_expected_no_timestamp)
 
         requests_path_expected = [
-            '/api/changes?timestamp_after=1970-01-01T00%3A00%3A00%2B00%3A00',
+            '/api/changes/?timestamp_after=1970-01-01T00%3A00%3A00%2B00%3A00',
             '/api/users/1?id=1&type=user',
             '/api/users/1?id=1&type=author',
             '/api/units/1',
@@ -253,7 +253,7 @@ class TestWeblateBackend(unittest.TestCase):
         self.assertListEqual(changes_no_timestamp, changes_expected_no_timestamp)
 
         requests_path_expected = [
-            '/api/changes?timestamp_after=2020-01-01T00%3A00%3A00%2B00%3A00',
+            '/api/changes/?timestamp_after=2020-01-01T00%3A00%3A00%2B00%3A00',
             '/api/users/2?id=3&type=user',
             '/api/users/2?id=3&type=author'
         ]
@@ -365,7 +365,7 @@ class TestWeblateClient(unittest.TestCase):
         self.assertListEqual(changes[1], changes_expected_page_2)
 
         requests_path_expected = [
-            '/api/changes',
+            '/api/changes/',
             '/api/changes/?page=2'
         ]
         self.assertEqual(len(http_requests), len(requests_path_expected))


### PR DESCRIPTION
This change is needed to fetch changes from weblate 4.7

'changes' must end with '/'as '.../api/changes/'  or it will
return 404 (Page Not Found).

There are 'unit' URLs that return 404 (Not Found) when they were
removed. It is now a WARNING instead of an ERROR to keep running.

Test updated accordingly.

Fixes #5

Signed-off-by: Quan Zhou <quan@bitergia.com>